### PR TITLE
Add Railway deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,33 @@
-FROM rust:1.85-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
+# Install trunk and WASM target
+RUN cargo install trunk --locked
+RUN rustup target add wasm32-unknown-unknown
+
+# Cache dependencies
 COPY Cargo.toml Cargo.lock ./
+COPY crates/dashboard/Cargo.toml crates/dashboard/Cargo.toml
 RUN mkdir src && echo 'fn main() {}' > src/main.rs
-RUN cargo build --release && rm -rf src
+RUN mkdir -p crates/dashboard/src && echo '#[allow(dead_code)] fn main() {}' > crates/dashboard/src/lib.rs
+RUN mkdir -p dist
+RUN cargo build --release 2>/dev/null || true
+RUN rm -rf src crates/dashboard/src dist
 
+# Copy full source
 COPY src ./src
-RUN touch src/main.rs && cargo build --release
+COPY crates/dashboard ./crates/dashboard
 
+# Build dashboard WASM first
+RUN cd crates/dashboard && trunk build --release
+
+# Build backend (embeds dist/ via rust-embed)
+RUN cargo build --release
+
+# Runtime
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

- Multi-stage Dockerfile that builds the dashboard WASM (trunk) before compiling the backend binary (rust-embed bakes dist/ into the binary)
- Rust version bumped from 1.85 to 1.88 to match CI
- New railway.toml for Dockerfile-based builds with health checks on /health

## Manual steps after merge

1. Create Railway project, add PostgreSQL addon
2. Connect zaptech-dev/reeverb repo (main branch)
3. Set env vars: JWT_SECRET, RUST_LOG=info, PORT=3000
4. DATABASE_URL auto-injected from Postgres addon

## Test plan

- [ ] `docker build -t reeverb .` builds successfully
- [ ] Container starts, /health returns 200
- [ ] Railway deploys on push to main