### PR TITLE
Fix project deserialization field mismatch

### DIFF
--- a/crates/dashboard/src/pages/dashboard.rs
+++ b/crates/dashboard/src/pages/dashboard.rs
@@ -6,7 +6,7 @@ use crate::api;
 
 #[derive(Clone, Serialize, Deserialize)]
 struct Project {
-    pid: String,
+    id: String,
     name: String,
     slug: String,
 }


### PR DESCRIPTION
## Summary

Dashboard `Project` struct expected `pid` but the API returns `id`. Renamed the frontend field to match the API response, fixing project creation and listing.

## Test plan

- [x] Create a project via the dashboard — no deserialization error
- [x] Project list loads correctly after creation